### PR TITLE
Re #4168 Get loggers in SFTP to log to sentry with proper stack traces. 

### DIFF
--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -20,10 +20,10 @@
 Server-mode SFTP support.
 """
 
+import logging
 import os
 import errno
 import sys
-import traceback
 from hashlib import md5, sha1
 
 from paramiko import util
@@ -49,6 +49,10 @@ _hash_class = {
     'sha1': sha1,
     'md5': md5,
 }
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
 
 
 class SFTPServer (BaseSFTP, SubsystemHandler):
@@ -84,12 +88,12 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
         self.folder_table = {}
         self.server = sftp_si(server, *largs, **kwargs)
 
-    def _log(self, level, msg):
+    def _log(self, level, msg, *args):
         if issubclass(type(msg), list):
             for m in msg:
-                super(SFTPServer, self)._log(level, m)
+                self._lot(level, msg, *args)
         else:
-            super(SFTPServer, self)._log(level, msg)
+            LOGGER.log(level, msg, exc_info=True, *args)
 
     def start_subsystem(self, name, transport, channel):
         self.sock = channel
@@ -104,7 +108,6 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
                 return
             except Exception as e:
                 self._log(ERROR, 'Exception on channel: ' + str(e))
-                self._log(ERROR, traceback.format_exc())
                 return
             msg = Message(data)
             request_number = msg.get_int()
@@ -112,7 +115,6 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
                 self._process(t, request_number, msg)
             except Exception as e:
                 self._log(ERROR, 'Exception in server processing: ' + str(e))
-                self._log(ERROR, traceback.format_exc())
                 # send some kind of failure message, at least
                 try:
                     self._send_status(request_number, SFTP_FAILURE)

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -91,7 +91,7 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
     def _log(self, level, msg, *args):
         if issubclass(type(msg), list):
             for m in msg:
-                self._lot(level, msg, *args)
+                self._log(level, msg, *args)
         else:
             LOGGER.log(level, msg, exc_info=True, *args)
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -20,6 +20,7 @@
 Core protocol implementation
 """
 
+import logging
 import os
 import socket
 import sys
@@ -80,6 +81,9 @@ def _join_lingering_threads():
 
 import atexit
 atexit.register(_join_lingering_threads)
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
 
 
 class Transport (threading.Thread, ClosingContextManager):
@@ -373,8 +377,7 @@ class Transport (threading.Thread, ClosingContextManager):
         self.clear_to_send_lock = threading.Lock()
         self.clear_to_send_timeout = 30.0
         self.log_name = 'paramiko.transport'
-        self.logger = util.get_logger(self.log_name)
-        self.packetizer.set_log(self.logger)
+        self.packetizer.set_log(LOGGER)
         self.auth_handler = None
         self.global_response = None     # response Message from an arbitrary global request
         self.completion_event = None    # user-defined event callbacks
@@ -1519,9 +1522,9 @@ class Transport (threading.Thread, ClosingContextManager):
     def _log(self, level, msg, *args):
         if issubclass(type(msg), list):
             for m in msg:
-                self.logger.log(level, m)
+                self._log(level, msg, *args)
         else:
-            self.logger.log(level, msg, *args)
+            LOGGER.log(level, msg, exc_info=True, *args)
 
     def _get_modulus_pack(self):
         """used by KexGex to find primes for group exchange"""

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1748,16 +1748,16 @@ class Transport (threading.Thread, ClosingContextManager):
                         self._send_message(msg)
                     self.packetizer.complete_handshake()
             except SSHException as e:
-                self._log(ERROR, "SSH Exception")
+                self._log(ERROR, str(e))
                 self.saved_exception = e
             except EOFError as e:
                 self._log(DEBUG, 'EOF in transport thread')
                 self.saved_exception = e
             except socket.error as e:
-                self._log(ERROR, "Socket Error")
+                self._log(ERROR, str(e))
                 self.saved_exception = e
             except Exception as e:
-                self._log(ERROR, "General Exception")
+                self._log(ERROR, str(e))
                 self.saved_exception = e
             _active_threads.remove(self)
             for chan in list(self._channels.values()):

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -25,7 +25,6 @@ import os
 import socket
 import sys
 import threading
-import traceback
 import time
 import weakref
 from hashlib import md5, sha1, sha256, sha512
@@ -1749,16 +1748,16 @@ class Transport (threading.Thread, ClosingContextManager):
                         self._send_message(msg)
                     self.packetizer.complete_handshake()
             except SSHException as e:
-                self._log(ERROR, traceback.format_exc())
+                self._log(ERROR, "SSH Exception")
                 self.saved_exception = e
             except EOFError as e:
                 self._log(DEBUG, 'EOF in transport thread')
                 self.saved_exception = e
             except socket.error as e:
-                self._log(ERROR, traceback.format_exc())
+                self._log(ERROR, "Socket Error")
                 self.saved_exception = e
             except Exception as e:
-                self._log(ERROR, traceback.format_exc())
+                self._log(ERROR, "General Exception")
                 self.saved_exception = e
             _active_threads.remove(self)
             for chan in list(self._channels.values()):


### PR DESCRIPTION
Paramiko is now updated to actually log errors instead of pushing those errors into the debug log. Plus this adds stack traces that are generated upon an error occurring.
