### PR TITLE
Empty read signals EOF

### DIFF
--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -352,6 +352,8 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
                     self._send_status(request_number, SFTP_EOF)
                 else:
                     self._response(request_number, CMD_DATA, data)
+            elif data is None:
+                self._send_status(request_number, SFTP_EOF)
             else:
                 self._send_status(request_number, data)
         elif t == CMD_WRITE:


### PR DESCRIPTION
Previously, this would except:
```
Traceback (most recent call last):
  File "/usr/local/smartfile/virtualenv/lib/python2.7/site-packages/paramiko/sftp_server.py", line 114, in start_subsystem
      self._process(t, request_number, msg)
  File "/usr/local/smartfile/virtualenv/lib/python2.7/site-packages/paramiko/sftp_server.py", line 356, in _process
      self._send_status(request_number, data)
  File "/usr/local/smartfile/virtualenv/lib/python2.7/site-packages/paramiko/sftp_server.py", line 214, in _send_status
      desc = SFTP_DESC[code]
  TypeError: list indices must be integers, not NoneType
```